### PR TITLE
Prevent adding modified date redundantly

### DIFF
--- a/post-date-modified.php
+++ b/post-date-modified.php
@@ -199,6 +199,12 @@ function filter_block( $block_content, array $block, WP_Block $instance ): strin
 	};
 	while ( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
 		if ( ! $processor->has_bookmark( 'first_opening_tag' ) && ! $processor->is_tag_closer() ) {
+			// Abort if the modified date was already added, which can currently happen with `gutenberg_block_bindings_render_block()`.
+			if ( $processor->has_class( 'post-date-modified' ) ) {
+				return $block_content;
+			}
+			$processor->add_class( 'post-date-modified' );
+
 			$processor->set_bookmark( 'first_opening_tag' );
 		} elseif ( $processor->is_tag_closer() ) {
 			$processor->set_bookmark( 'last_closing_tag' );


### PR DESCRIPTION
Normal stack trace when the filter callback applies:

```
post-date-modified.php:136, PostDateModified\filter_block()
class-wp-hook.php:341, WP_Hook->apply_filters()
plugin.php:205, apply_filters()
class-wp-block.php:663, WP_Block->render()
class-wp-block.php:576, WP_Block->render()
class-wp-block.php:576, WP_Block->render()
class-wp-block.php:576, WP_Block->render()
class-wp-block.php:576, WP_Block->render()
blocks.php:2378, render_block()
blocks.php:2465, do_blocks()
block-template.php:291, get_the_block_template_html()
template-canvas.php:12, include()
template-loader.php:125, require_once()
wp-blog-header.php:19, require()
_index.php:17, require_once()
index.php:19, {main}()
```

Additional stack trace which applies when the callback runs a second time when Gutenberg is active:

```
post-date-modified.php:136, PostDateModified\filter_block()
class-wp-hook.php:341, WP_Hook->apply_filters()
plugin.php:205, apply_filters()
class-wp-block.php:663, WP_Block->render()
block-bindings.php:97, gutenberg_block_bindings_render_block()
class-wp-hook.php:341, WP_Hook->apply_filters()
plugin.php:205, apply_filters()
class-wp-block.php:648, WP_Block->render()
class-wp-block.php:576, WP_Block->render()
class-wp-block.php:576, WP_Block->render()
class-wp-block.php:576, WP_Block->render()
class-wp-block.php:576, WP_Block->render()
blocks.php:2378, render_block()
blocks.php:2465, do_blocks()
block-template.php:291, get_the_block_template_html()
template-canvas.php:12, include()
template-loader.php:125, require_once()
wp-blog-header.php:19, require()
_index.php:17, require_once()
index.php:19, {main}()
```